### PR TITLE
Fix bug in dimension value for diagnostics function

### DIFF
--- a/h2o-py/demos/kmeans_aic_bic_diagnostics.ipynb
+++ b/h2o-py/demos/kmeans_aic_bic_diagnostics.ipynb
@@ -1662,7 +1662,7 @@
     "def diagnostics_from_clusteringmodel(model):\n",
     "    total_within_sumofsquares = model.tot_withinss()\n",
     "    number_of_clusters = len(model.centers())\n",
-    "    number_of_dimensions = len(model.centers())\n",
+    "    number_of_dimensions = len(model.centers()[0])\n",
     "    number_of_rows = sum(model.size())\n",
     "    \n",
     "    aic = total_within_sumofsquares + 2 * number_of_dimensions * number_of_clusters\n",


### PR DESCRIPTION
The number of dimensions was set to the number of centroids. Surely the dimensions should be constant for this example. It can be found by getting the length of any of the centroid lists.
